### PR TITLE
[DEV-2443] Amount with currency symbol

### DIFF
--- a/infrastructure/bicep/lightning-api.bicep
+++ b/infrastructure/bicep/lightning-api.bicep
@@ -30,6 +30,8 @@ param umaSigningPrivKey string
 param umaSigningPubKey string
 param umaEncryptionPubKey string
 
+param commonPaymentAddress string
+
 @secure()
 param coingeckoApiKey string
 
@@ -343,6 +345,10 @@ resource apiAppService 'Microsoft.Web/sites@2018-11-01' =
           {
             name: 'UMA_ENCRYPTION_PUB_KEY'
             value: umaEncryptionPubKey
+          }
+          {
+            name: 'COMMON_PAYMENT_ADDRESS'
+            value: commonPaymentAddress
           }
           {
             name: 'COIN_GECKO_API_KEY'

--- a/infrastructure/bicep/parameters/dev.json
+++ b/infrastructure/bicep/parameters/dev.json
@@ -53,6 +53,9 @@
     "umaEncryptionPubKey": {
       "value": "xxx"
     },
+    "commonPaymentAddress": {
+      "value": "xxx"
+    },
     "coingeckoApiKey": {
       "value": "xxx"
     }

--- a/infrastructure/bicep/parameters/loc.json
+++ b/infrastructure/bicep/parameters/loc.json
@@ -53,6 +53,9 @@
     "umaEncryptionPubKey": {
       "value": "xxx"
     },
+    "commonPaymentAddress": {
+      "value": "xxx"
+    },
     "coingeckoApiKey": {
       "value": "xxx"
     }

--- a/infrastructure/bicep/parameters/prd.json
+++ b/infrastructure/bicep/parameters/prd.json
@@ -53,6 +53,9 @@
     "umaEncryptionPubKey": {
       "value": "xxx"
     },
+    "commonPaymentAddress": {
+      "value": "xxx"
+    },
     "coingeckoApiKey": {
       "value": "xxx"
     }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -67,6 +67,8 @@ export class Configuration {
     signature: /^(.{87}=)$/,
   };
 
+  commonPaymentAddress = process.env.COMMON_PAYMENT_ADDRESS;
+
   blockchain = {
     lightning: {
       lnbits: {

--- a/src/integration/blockchain/lightning/lightning-client.ts
+++ b/src/integration/blockchain/lightning/lightning-client.ts
@@ -5,6 +5,7 @@ import { Config } from 'src/config/config';
 import { HttpRequestConfig, HttpService } from 'src/shared/services/http.service';
 import { LightningLogger } from 'src/shared/services/lightning-logger';
 import { Util } from 'src/shared/utils/util';
+import { LightingWalletPaymentParamDto } from 'src/subdomains/lightning/dto/lightning-wallet.dto';
 import {
   LnBitsLnurlPayRequestDto,
   LnBitsLnurlWithdrawRequestDto,
@@ -390,19 +391,17 @@ export class LightningClient {
 
   async getLnBitsWalletPayment(
     adminKey: string,
-    amount: number,
-    currencyCode: string,
+    walletPaymentParam: LightingWalletPaymentParamDto,
   ): Promise<LnBitsLnurlpInvoiceDto> {
-    const memo = `Pay this Lightning bill to transfer ${amount} ${currencyCode.toUpperCase()}`;
-
     return this.http
       .post<LnBitsWalletPaymentDto>(
         `${Config.blockchain.lightning.lnbits.apiUrl}/payments`,
         {
           out: false,
-          amount: amount,
-          unit: currencyCode,
-          memo: memo,
+          amount: walletPaymentParam.amount,
+          unit: walletPaymentParam.currencyCode,
+          memo: walletPaymentParam.memo,
+          expiry: 60,
         },
         this.httpLnBitsConfig(adminKey),
       )

--- a/src/integration/blockchain/uma/services/uma.service.ts
+++ b/src/integration/blockchain/uma/services/uma.service.ts
@@ -209,7 +209,7 @@ export class UmaService {
       await this.checkPayRequest(receiverVaspDomain, payRequest);
 
       const currencyCode = payRequest.currency;
-      const currency = this.lightningCurrencyService.getCurrency(currencyCode);
+      const currency = this.lightningCurrencyService.getCurrencyByCode(currencyCode);
       if (!currency) throw new BadRequestException(`Unknown currency ${currencyCode}`);
 
       const conversionRate = await this.lightningCurrencyService.getMultiplier(currency);

--- a/src/subdomains/lightning/dto/lightning-wallet.dto.ts
+++ b/src/subdomains/lightning/dto/lightning-wallet.dto.ts
@@ -1,0 +1,6 @@
+export interface LightingWalletPaymentParamDto {
+  address: string;
+  currencyCode?: string;
+  amount?: string;
+  memo?: string;
+}

--- a/src/subdomains/lightning/services/__test__/lightning-currency-service.spec.ts
+++ b/src/subdomains/lightning/services/__test__/lightning-currency-service.spec.ts
@@ -1,0 +1,172 @@
+import { createMock } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestUtil } from 'src/shared/utils/test.util';
+import { CoinGeckoService } from 'src/subdomains/support/services/coingecko.service';
+import { LightingWalletPaymentParamDto } from '../../dto/lightning-wallet.dto';
+import { LightningCurrencyService } from '../lightning-currency.service';
+
+describe('LightningCurrencyService', () => {
+  let service: LightningCurrencyService;
+  let coingeckoService: CoinGeckoService;
+
+  beforeAll(async () => {
+    const config = {
+      commonPaymentAddress: 'TestEVMPaymentAddress',
+    };
+
+    coingeckoService = createMock<CoinGeckoService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LightningCurrencyService,
+        { provide: CoinGeckoService, useValue: coingeckoService },
+        TestUtil.provideConfig(config),
+      ],
+    }).compile();
+
+    service = module.get<LightningCurrencyService>(LightningCurrencyService);
+    service.onModuleInit();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should detect valid currency', () => {
+    const address = 'x';
+
+    const paymentParams = service.getWalletPaymentParam(address, { amount: '122.44' });
+
+    expect(paymentParams.currencyCode).toBeUndefined();
+    expect(paymentParams.amount).toBe('122.44');
+  });
+
+  it('should detect valid currency and amount', () => {
+    const address = 'x';
+
+    checkPaymentParams(service.getWalletPaymentParam(address, { currency: 'usd', amount: '122.44' }), '122.44', 'usd');
+    checkPaymentParams(service.getWalletPaymentParam(address, { currency: 'eur', amount: '0.02' }), '0.02', 'eur');
+    checkPaymentParams(service.getWalletPaymentParam(address, { currency: 'chf', amount: '100' }), '100', 'chf');
+    checkPaymentParams(service.getWalletPaymentParam(address, { currency: 'sat', amount: '1200.' }), '1200.', 'sat');
+  });
+
+  it('should detect valid amount and symbol', () => {
+    const address = 'x';
+
+    checkPaymentParams(service.getWalletPaymentParam(address, { amount: '$122.44' }), '122.44', 'usd');
+    checkPaymentParams(service.getWalletPaymentParam(address, { amount: '€0.02' }), '0.02', 'eur');
+    checkPaymentParams(service.getWalletPaymentParam(address, { amount: '₣100' }), '100', 'chf');
+    checkPaymentParams(service.getWalletPaymentParam(address, { amount: '§1200.' }), '1200.', 'sat');
+  });
+
+  function checkPaymentParams(
+    paymentParams: LightingWalletPaymentParamDto,
+    checkAmount: string,
+    checkCurrencyCode: string,
+  ) {
+    expect(paymentParams.amount).toBe(checkAmount);
+    expect(paymentParams.currencyCode).toBe(checkCurrencyCode);
+  }
+
+  it('should just pass through', () => {
+    const address = 'x';
+
+    expect(service.getWalletPaymentParam(address, { amount: '' })).toStrictEqual({
+      address: 'x',
+      currencyCode: undefined,
+      amount: '',
+    });
+    expect(service.getWalletPaymentParam(address, { amount: '&12' })).toStrictEqual({
+      address: 'x',
+      currencyCode: undefined,
+      amount: '&12',
+    });
+    expect(service.getWalletPaymentParam(address, { amount: 'Hello' })).toStrictEqual({
+      address: 'x',
+      currencyCode: undefined,
+      amount: 'Hello',
+    });
+    expect(service.getWalletPaymentParam(address, { amount: '33,44' })).toStrictEqual({
+      address: 'x',
+      currencyCode: undefined,
+      amount: '33,44',
+    });
+    expect(service.getWalletPaymentParam(address, { amount: '1.2.3' })).toStrictEqual({
+      address: 'x',
+      currencyCode: undefined,
+      amount: '1.2.3',
+    });
+  });
+
+  it('should detect invalid currency', () => {
+    expect(service.getCurrencyBySymbol('')).toBeUndefined();
+    expect(service.getCurrencyBySymbol('x')).toBeUndefined();
+    expect(service.getCurrencyBySymbol('Hello')).toBeUndefined();
+    expect(service.getCurrencyBySymbol('128')).toBeUndefined();
+  });
+
+  it('should detect all valid currencies', () => {
+    const currencies = service.getCurrencies();
+    expect(currencies.length).toBeGreaterThan(0);
+
+    for (let i = 0; i < currencies.length; i++) {
+      const currency = currencies[i];
+
+      expect(service.getCurrencyByCode(currency.code)?.code).toBe(currency.code);
+      expect(service.getCurrencyBySymbol(currency.symbol)?.symbol).toBe(currency.symbol);
+
+      const address = 'x';
+      const amount = (i + 1) * 10;
+      const paymentParam = service.getWalletPaymentParam(address, { amount: `${currency.symbol}${amount}` });
+
+      expect(paymentParam.amount).toBe(amount.toString());
+      expect(paymentParam.currencyCode).toBe(currency.code);
+    }
+  });
+
+  it('should detect valid payment params', () => {
+    const address = 'x';
+
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'usd', amount: '1000' })).not.toThrow();
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'eur', amount: '0.02' })).not.toThrow();
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'chf', amount: '222.99' })).not.toThrow();
+  });
+
+  it('should detect invalid payment params', () => {
+    const address = 'x';
+
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'xyz', amount: '100' })).toThrow(
+      'Unknown currency xyz',
+    );
+
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'usd', amount: 'xyz' })).toThrow(
+      'USD amount xyz must be a number',
+    );
+
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'eur', amount: '0.0099' })).toThrow(
+      'EUR amount 0.0099 is lower than min. 0.01',
+    );
+
+    expect(() => service.walletPaymentParamCheck({ address, currencyCode: 'chf', amount: '100001' })).toThrow(
+      'CHF amount 100001 is higher than max. 10000',
+    );
+  });
+
+  it('should create wallet memo', () => {
+    const walletPaymentParam: LightingWalletPaymentParamDto = {
+      address: 'TestLightningAddress',
+      currencyCode: 'usd',
+      amount: '100',
+    };
+    service.fillWalletPaymentMemo(walletPaymentParam);
+
+    expect(walletPaymentParam.memo).toBe('Pay this Lightning bill to transfer 100 USD to TestLightningAddress.');
+
+    walletPaymentParam.currencyCode = 'chf';
+    service.fillWalletPaymentMemo(walletPaymentParam);
+
+    expect(walletPaymentParam.memo).toBe(
+      'Pay this Lightning bill to transfer 100 CHF to TestLightningAddress. Alternatively, send 100 CHF to TestEVMPaymentAddress via Ethereum, Polygon, Arbitrum, Optimism or Base.',
+    );
+  });
+});


### PR DESCRIPTION
1. changed expiry time to 60 seconds
2. currency symbol can be used in the "amount" parameter (allowed currency symbols are '$', '₣', '€', '§')
3. added lightning address to memo
4. added alternative payment info in case of "CHF" payment request
5. added test cases for "LightningCurrencyService"