### PR TITLE
Remove RBTC, rename USDT_CITREA to JUSD_CITREA, fix contract

### DIFF
--- a/infrastructure/config/boltz/backend/dev-boltz.conf
+++ b/infrastructure/config/boltz/backend/dev-boltz.conf
@@ -131,13 +131,13 @@ minSwapAmount = 2_500      # 2,500 sats minimum (Citrea Testnet has low fees)
 
 [[pairs]]
 base = "USDT_ETH"
-quote = "USDT_CITREA"
+quote = "JUSD_CITREA"
 rate = 1
 fee = 0.25
 swapInFee = 0.1
 
-maxSwapAmount = 1_000_000_000 # 1000 USDT_ETH/USDT_CITREA
-minSwapAmount = 1_000_000     # 1 USDT_ETH/USDT_CITREA
+maxSwapAmount = 1_000_000_000 # 1000 USDT_ETH/JUSD_CITREA
+minSwapAmount = 1_000_000     # 1 USDT_ETH/JUSD_CITREA
 
   [pairs.timeoutDelta]
   chain = 1440        # Chain swap timeout (~24 hours = 144 blocks)
@@ -148,13 +148,13 @@ minSwapAmount = 1_000_000     # 1 USDT_ETH/USDT_CITREA
 
 [[pairs]]
 base = "USDT_POLYGON"
-quote = "USDT_CITREA"
+quote = "JUSD_CITREA"
 rate = 1
 fee = 0.25
 swapInFee = 0.1
 
-maxSwapAmount = 1_000_000_000 # 1000 USDT_POLYGON/USDT_CITREA
-minSwapAmount = 1_000_000     # 1 USDT_POLYGON/USDT_CITREA
+maxSwapAmount = 1_000_000_000 # 1000 USDT_POLYGON/JUSD_CITREA
+minSwapAmount = 1_000_000     # 1 USDT_POLYGON/JUSD_CITREA
 
   [pairs.timeoutDelta]
   chain = 1440        # Chain swap timeout (~24 hours = 144 blocks)
@@ -210,8 +210,8 @@ providerEndpoint = "https://dev.rpc.testnet.juiceswap.com"
   minWalletBalance = 100_000
 
   [[citrea.tokens]]
-  symbol = "USDT_CITREA"
+  symbol = "JUSD_CITREA"
   decimals = 6
   contractAddress = "0xFdB0a83d94CD65151148a131167Eb499Cb85d015"
 
-  minWalletBalance = 1_000_000   # 1 USDT_CITREA
+  minWalletBalance = 1_000_000   # 1 JUSD_CITREA


### PR DESCRIPTION
## Summary

- Remove BTC/RBTC swap pair and RSK network configuration
- Rename USDT_CITREA to JUSD_CITREA (correct token name)
- Fix JUSD contract address on Citrea Testnet

## Changes

### 1. Remove RBTC/RSK
- Remove BTC/RBTC swap pair
- Remove RSK network configuration and contracts

### 2. Rename USDT_CITREA → JUSD_CITREA
The token on Citrea Testnet is "Juice Dollar" (JUSD), not USDT.

### 3. Fix Contract Address
- Old: `0x1Dd3057888944ff1f914626aB4BD47Dc8b6285Fe` (wrong JUSD)
- New: `0xFdB0a83d94CD65151148a131167Eb499Cb85d015` (correct JUSD)

## Final Swap Pairs

| From | To |
|------|-----|
| BTC | BTC (Lightning ↔ OnChain) |
| BTC | cBTC (Bitcoin ↔ Citrea) |
| USDT_ETH | JUSD_CITREA |
| USDT_POLYGON | JUSD_CITREA |