### PR TITLE
Add debug role migration for wallet

### DIFF
--- a/migration/1769522277000-addDebugWallet.js
+++ b/migration/1769522277000-addDebugWallet.js
@@ -1,0 +1,13 @@
+const { MigrationInterface, QueryRunner } = require("typeorm");
+
+module.exports = class addDebugWallet1769522277000 {
+    name = 'addDebugWallet1769522277000'
+
+    async up(queryRunner) {
+        await queryRunner.query(`UPDATE wallet SET role = 'Debug', updated = GETDATE() WHERE address = '0xB0bAadE3e6E53aF8ba921AEB245EDEa18322EeFE'`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`UPDATE wallet SET role = 'User', updated = GETDATE() WHERE address = '0xB0bAadE3e6E53aF8ba921AEB245EDEa18322EeFE'`);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds migration to grant DEBUG role to wallet `0xB0bAadE3e6E53aF8ba921AEB245EDEa18322EeFE`
- Enables access to `/support/debug` endpoints for database queries and log access

## Test plan
- [ ] Deploy migration to production
- [ ] Verify wallet can access debug endpoints