### PR TITLE
Fix circular dependency crash: add missing forwardRef

### DIFF
--- a/src/subdomains/user/application/services/lightning-wallet.service.ts
+++ b/src/subdomains/user/application/services/lightning-wallet.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { Config } from 'src/config/config';
 import {
   LnBitsTransactionDto,
@@ -46,6 +46,7 @@ export class LightningWalletService {
   constructor(
     readonly lightningService: LightningService,
     readonly lnbitsWebHookService: LnbitsWebHookService,
+    @Inject(forwardRef(() => MonitoringService))
     private readonly monitoringService: MonitoringService,
     private readonly assetService: AssetService,
     private readonly lightningTransactionService: LightningTransactionService,


### PR DESCRIPTION
## HOTFIX - Production is down (503)

PR #148 introduced a circular service dependency between `MonitoringService` and `LightningWalletService`, but only added `forwardRef` on the `MonitoringService` side. The missing `forwardRef` on `LightningWalletService` causes NestJS to fail resolving dependencies at startup.

## Fix
Add `@Inject(forwardRef(() => MonitoringService))` to `LightningWalletService` constructor.

## Test plan
- [ ] App starts without DI errors
- [ ] `/monitoring/btc` loads correctly