### PR TITLE
Make UTXO table collapsible under Onchain BTC row

### DIFF
--- a/src/assets/monitoring-btc.html
+++ b/src/assets/monitoring-btc.html
@@ -71,6 +71,14 @@
     }
     .range-buttons button.active { color: #4fc3f7; border-color: #4fc3f7; }
     .range-buttons button:hover { color: #fff; }
+    .expandable { cursor: pointer; }
+    .expandable td:first-child::before { content: '\25B6 '; font-size: 9px; color: #555; }
+    .expandable.open td:first-child::before { content: '\25BC '; }
+    .utxo-details { display: none; }
+    .utxo-details.open { display: table-row; }
+    .utxo-details td { padding: 0; }
+    .utxo-details table { margin: 0; font-size: 12px; background: #111; }
+    .utxo-details th, .utxo-details td { padding: 4px 12px; border-bottom: 1px solid #1a1a1a; }
   </style>
 </head>
 <body>
@@ -96,13 +104,6 @@
 
   <div id="content">
     <div class="loading">Loading BTC monitoring data...</div>
-  </div>
-
-  <div class="section">
-    <h2>Bitcoin Core UTXOs (On-Chain Verification)</h2>
-    <div id="utxo-content">
-      <div class="loading">Loading UTXO data...</div>
-    </div>
   </div>
 
   <script src="/monitoring/chart.min.js"></script>

--- a/src/assets/monitoring-btc.js
+++ b/src/assets/monitoring-btc.js
@@ -92,15 +92,24 @@ function render(data) {
   html += '<tr><th>Source</th><th>Location</th><th class="number">BTC</th></tr>';
   for (var i = 0; i < holdings.length; i++) {
     var h = holdings[i];
-    html += '<tr>';
-    html += '<td>' + h.source + '</td>';
-    if (h.explorer) {
-      html += '<td><a href="' + h.explorer + '" target="_blank" rel="noopener">' + h.location + '</a></td>';
-    } else {
+    if (h.source === 'Onchain BTC') {
+      html += '<tr class="expandable" id="onchain-row">';
+      html += '<td>' + h.source + '</td>';
       html += '<td>' + h.location + '</td>';
+      html += '<td class="number">' + fmtBtc(h.btc) + '</td>';
+      html += '</tr>';
+      html += '<tr class="utxo-details" id="utxo-row"><td colspan="3"><div id="utxo-content"><span class="loading">Loading UTXOs...</span></div></td></tr>';
+    } else {
+      html += '<tr>';
+      html += '<td>' + h.source + '</td>';
+      if (h.explorer) {
+        html += '<td><a href="' + h.explorer + '" target="_blank" rel="noopener">' + h.location + '</a></td>';
+      } else {
+        html += '<td>' + h.location + '</td>';
+      }
+      html += '<td class="number">' + fmtBtc(h.btc) + '</td>';
+      html += '</tr>';
     }
-    html += '<td class="number">' + fmtBtc(h.btc) + '</td>';
-    html += '</tr>';
   }
   html += '<tr class="total-row">';
   html += '<td>Total</td><td></td>';
@@ -124,6 +133,20 @@ function render(data) {
   html += '</div>';
 
   content.innerHTML = html;
+
+  var onchainRow = document.getElementById('onchain-row');
+  var utxoRow = document.getElementById('utxo-row');
+  var utxosLoaded = false;
+  if (onchainRow && utxoRow) {
+    onchainRow.addEventListener('click', function () {
+      onchainRow.classList.toggle('open');
+      utxoRow.classList.toggle('open');
+      if (!utxosLoaded) {
+        utxosLoaded = true;
+        loadUtxos();
+      }
+    });
+  }
 }
 
 var btcChart = null;
@@ -244,7 +267,6 @@ function renderUtxos(data) {
 
 loadData();
 loadChart('24h');
-loadUtxos();
 
 var rangeButtons = document.querySelectorAll('.range-buttons button[data-range]');
 for (var i = 0; i < rangeButtons.length; i++) {


### PR DESCRIPTION
## Summary
- Remove standalone UTXO section from the page
- UTXO table is now nested inside the holdings table, hidden by default
- Click on "Onchain BTC" row to expand/collapse the UTXO breakdown
- UTXOs are loaded lazily on first click (no extra API call on page load)
- Arrow indicator (▶/▼) shows expand/collapse state

## Test plan
- [ ] UTXO section is not visible on page load
- [ ] Clicking "Onchain BTC" row expands the UTXO table below it
- [ ] Clicking again collapses it
- [ ] UTXO addresses link to mempool.space
- [ ] UTXO total matches the Onchain BTC balance